### PR TITLE
canned query data issues

### DIFF
--- a/lib/summon/transport/canned.json
+++ b/lib/summon/transport/canned.json
@@ -1490,7 +1490,10 @@
 
     ],
     "textQueries": [
-
+      {
+        "textQuery": "louis%2Crmstrong",
+        "removeCommand": "removeTextQuery(louis%2Crmstrong)"
+      }
     ],
     "sort": [
 


### PR DESCRIPTION
some of the data in the canned.json file were not properly presenting the search query. this makes for an inconsistent query object. I took a look at the query that was done and the result the summon API would give back in the query. for the queryString I added s.q, s.pn and s.ps and added the s.q to the textQueries array in it's proper format.

I did not bump the version yet for review and later additions
