### PR TITLE
properly encode query parameters in 1.9

### DIFF
--- a/lib/summon/transport/qstring.rb
+++ b/lib/summon/transport/qstring.rb
@@ -1,9 +1,10 @@
 
 require 'cgi'
+require 'uri'
 
 module Summon::Transport
   module Qstring
-  
+
     def to_query_string(hash, urlencode = true)
       hash.reject {|k,v| v.nil? || v == ''}.inject([]) do |qs,pair|
         qs.tap do
@@ -16,21 +17,25 @@ module Summon::Transport
             qs << encode_param(k, v, urlencode)
           end
         end
-      end.reject{|o| o.nil? || o.empty?}.sort.join('&')        
+      end.reject{|o| o.nil? || o.empty?}.sort.join('&')
     end
 
     def urlencode(str)
-      str.gsub(/[^a-zA-Z0-9_\.\-]/n) {|s| sprintf('%%%02x', s[0].ord) }
+      if URI.respond_to?(:encode_www_form_component)
+        URI.encode_www_form_component str
+      else
+        str.gsub(/[^a-zA-Z0-9_\.\-]/n) {|s| sprintf('%%%02x', s[0].ord) }
+      end
     end
 
     def urldecode(str)
       CGI.unescape(str)
     end
-  
+
     def encode_param(k, v, do_urlencode)
       "#{k.to_s}=#{do_urlencode ? urlencode(v.to_s) : v.to_s}"
     end
-    
+
     def from_query_string(qstr)
       qstr ||= ""
       {}.tap do |result|
@@ -42,8 +47,8 @@ module Summon::Transport
           else
             result[k] = urldecode(v)
           end
-        end        
+        end
       end
     end
-  end 
+  end
 end

--- a/lib/summon/version.rb
+++ b/lib/summon/version.rb
@@ -1,4 +1,4 @@
 
 module Summon
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end

--- a/spec/summon/transport/qstring_spec.rb
+++ b/spec/summon/transport/qstring_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 require File.dirname(__FILE__) + '/../../spec_helper'
 
 describe Summon::Transport::Qstring do
@@ -24,11 +25,11 @@ describe Summon::Transport::Qstring do
 
   it "encodes strings properly" do
     to_query_string("foo" => "bar").should == "foo=bar"
-    to_query_string("foo" => "*").should == "foo=%2a"
+    to_query_string("foo" => "/").downcase.should == "foo=%2f"
   end
 
-  it "encodes UTF-8 strings on 1.9" do
-
-  end if RUBY_VERSION >= '1.9'
+  it "encodes UTF-8 strings" do
+    to_query_string("s.q"=> "らしさ」を失わな").downcase.should eql "s.q=%e3%82%89%e3%81%97%e3%81%95%e3%80%8d%e3%82%92%e5%a4%b1%e3%82%8f%e3%81%aa"
+  end
 
 end


### PR DESCRIPTION
The authorization headers were incorrect because we weren't properly encoding UTF-8 characters in 1.9

Luckily, 1.9 has added better methods for encoding url components
