### PR TITLE
support signing empty param values, e.g. 's.q='

### DIFF
--- a/lib/summon/transport/headers.rb
+++ b/lib/summon/transport/headers.rb
@@ -43,7 +43,7 @@ module Summon::Transport
     end
 
     def qstr
-      to_query_string(@params, false)
+      to_query_string(@params, false, lambda {|k,v| v.nil? })
     end
 
     private

--- a/lib/summon/transport/qstring.rb
+++ b/lib/summon/transport/qstring.rb
@@ -5,8 +5,9 @@ require 'uri'
 module Summon::Transport
   module Qstring
 
-    def to_query_string(hash, urlencode = true)
-      hash.reject {|k,v| v.nil? || v == ''}.inject([]) do |qs,pair|
+    def to_query_string(hash, urlencode = true,
+			reject = lambda {|k,v| v.nil? || v == ''})
+      hash.reject(&reject).inject([]) do |qs,pair|
         qs.tap do
           k,v = pair
           if v.is_a?(Array)


### PR DESCRIPTION
As long as an empty value for a param (e.g., `s.q=`) is legal, we should support signing it. Current implementation simply drops params with empty values, which without reporting back to the caller, results in invalid auth headers. This should also be supported because in practice, sometimes having a parameter key present with an empty value can differ semantically from having no value explicitly specified for that parameter.

I believe this implementation is backward-compatible, and should support different ways of handling blank and nil params.