### PR TITLE
Update client to work with https endpoint and make https the default

### DIFF
--- a/lib/summon/service.rb
+++ b/lib/summon/service.rb
@@ -5,7 +5,7 @@ module Summon
     attr_reader :transport, :url, :access_id, :client_key
     
     def initialize(options = {})
-      @url        = options[:url] || "http://api.summon.serialssolutions.com/2.0.0"
+      @url        = options[:url] || "https://api.summon.serialssolutions.com/2.0.0"
       @access_id  = options[:access_id]
       @secret_key = options[:secret_key]
       @client_key = options[:client_key]

--- a/lib/summon/transport/http.rb
+++ b/lib/summon/transport/http.rb
@@ -5,7 +5,7 @@ module Summon::Transport
   class Http
     include Qstring
 
-    DEFAULTS = {:url => "http://api.summon.serialssolutions.com"}
+    DEFAULTS = {:url => "https://api.summon.serialssolutions.com"}
 
     def initialize(options = {:url => nil, :access_id => nil, :secret_key => nil, :client_key => nil, :session_id => nil, :log => nil})
       @options    = DEFAULTS.merge options
@@ -47,6 +47,7 @@ module Summon::Transport
         }
         result = nil
           http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = uri.scheme == "https"
           http.start do
             get = Net::HTTP::Get.new("#{uri.path}#{'?' + uri.query if uri.query && uri.query != ''}")
             get.merge! headers

--- a/spec/summon/service_spec.rb
+++ b/spec/summon/service_spec.rb
@@ -12,7 +12,7 @@ describe Summon::Service do
   end
   
   it "has a default url which is the public production summon url" do
-    Summon::Service.new.url.should == "http://api.summon.serialssolutions.com/2.0.0"
+    Summon::Service.new.url.should == "https://api.summon.serialssolutions.com/2.0.0"
   end
 
   it "allows cloning a service with overridden settings" do


### PR DESCRIPTION
- Update client to set use_https on Net::HTTP based on schema of URL.
- Change the default API server URL to the https address: `https://api.summon.serialssolutions.com/2.0.0`.